### PR TITLE
fix(WithAuth): `options.authRequired` can default to `undefined`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export const WithAuth = <
   TBase extends Constructor<Server<Env>> | Constructor<AIChatAgent<Env>>,
 >(
   Base: TBase,
-  options: WithAuthParams = { authRequired: true },
+  options: WithAuthParams = {},
 ) => {
   const authRequired = options.authRequired ?? true;
   const debug = options.debug ?? (() => {});
@@ -209,7 +209,7 @@ export const WithAuth = <
     async onRequest(req: Request) {
       try {
         const tokenSet = this.#getTokenSetFromRequest(req);
-        if (options.authRequired) {
+        if (authRequired) {
           await this.#validateTokenFromRequest(req);
           return this.#asyncTokenStorage.run(tokenSet, async () => {
             const authResponse = await this.onAuthenticatedRequest(req);


### PR DESCRIPTION
The `options.authRequired` check in `onRequest` is causing unexpected behavior. The docs say that `authRequired` defaults to `true`. However the way `WithAuth` is written, if an empty options object or an options object with only `debug` is provided, `authRequired` defaults to `undefined`.

This wouldn't be a problem because the local `authRequired` is set to `true` if `options.authRequired` is nullish, but `onRequest` checks `options.authRequired` instead of `authRequired`. For me this was causing `onAuthenticatedRequest` not to fire even though my request was providing an access token.

This PR changes `onRequest` to use the local `authRequired`. It also sets the `options` default value to `{}` instead of `{ authRequired: true }` in an effort to prevent similar bugs in the future. Setting `{ authRequired: true }` as the default value for `options` can only lead to confusion since the logic inside `WithAuth` should be using the local `authRequired` anyways.